### PR TITLE
[Feat]: Added drag and drop box in Dashboard

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,35 @@
+export const OPS = {
+    CREATE: "CREATE",
+    FETCH: "FETCH",
+    UPDATE: "UPDATE",
+    UPDATE_ALL: "UPDATE MULTIPLE",
+    FILTER: "FILTER",
+    INFO: "ACCOUNT"
+};
+
+export const OP_DATA = {
+    [OPS.CREATE]: {
+        from: "commit",
+        requiredFields: ['address', 'amount', 'data']
+    },
+    [OPS.FETCH]: {
+        from: "get",
+        requiredFields: ['id']
+    },
+    [OPS.UPDATE]: {
+        from: "update",
+        requiredFields: ['address', 'amount', 'data', 'id']
+    },
+    [OPS.UPDATE_ALL]: {
+        from: "update-multi",
+        requiredFields: ['values']
+    },
+    [OPS.FILTER]: {
+        from: "filter",
+        requiredFields: ['recipientPublicKey']
+    },
+    [OPS.INFO]: {
+        from: "account",
+        requiredFields: []
+    }
+}

--- a/src/css/App.css
+++ b/src/css/App.css
@@ -2581,6 +2581,31 @@ body.panel-closing .page, body.panel-closing .bottom-toolbar {
 .switch input:checked + .switch__label:active::before {
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.28), 0 0 0 20px rgba(0, 150, 136, 0.2); }
 
+.drag_box {
+  margin: -5px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  .drag_box_outline {
+    border: 2px rgb(71 231 206 / 80%);
+    padding: 10px;
+    width: 100%;
+    border-style: dashed;
+    border-radius: 7px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .erred {
+    border-color: red;
+    span {
+      color: red;
+    }
+  }
+}
+
 .fieldset {
   width: calc(100% - 40px);
   padding: 20px;


### PR DESCRIPTION
## Feature Addition: Drag and Drop JSON Support in Dashboard Page

### Overview
Added a drag-and-drop box to the Dashboard page, enabling users to navigate dynamically based on valid JSON data.

### Preview:
![Screenshot from 2024-02-18 16-14-59](https://github.com/apache/incubator-resilientdb-resvault/assets/43518222/4ea90885-6c24-4c85-9550-73896e346f0f)


### Example Usage
Users can drop JSON objects containing operation details, such as:

#### Example for `CREATE` Operation:
```json
{
  "operation": "CREATE",
  "address": "some_address",
  "amount": 100,
  "data": "some_data"
}
```

#### Example for `FETCH` Operation:
```json
{
  "operation": "FETCH",
  "id": "some_id"
}
```

#### Example for `UPDATE` Operation:
```json
{
  "operation": "UPDATE_ALL",
  "values": "some_values"
}
```

#### Example for `UPDATE_ALL` Operation:
```json
{
  "operation": "UPDATE",
  "address": "some_address",
  "amount": 150,
  "data": "updated_data",
  "id": "some_id"
}
```

#### Example for `FILTER` Operation:
```json
{
  "operation": "FILTER",
  "recipientPublicKey": "some_public_key"
}
```

#### Example for `INFO` Operation:
```json
{
  "operation": "INFO"
}
```